### PR TITLE
Creating Packer template for creating snapshot on Digital Ocean

### DIFF
--- a/packer/config/example.com/example.com
+++ b/packer/config/example.com/example.com
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name example.com;
+
+    location / {
+        root /var/www/html/example.com;
+        index index.html index.htm;
+    }
+}

--- a/packer/config/example.com/index.html
+++ b/packer/config/example.com/index.html
@@ -1,0 +1,1 @@
+Hello world!

--- a/packer/config/nginx.conf
+++ b/packer/config/nginx.conf
@@ -1,0 +1,50 @@
+user www-data;
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+
+    include /etc/nginx/conf.d/*.conf;
+    include /etc/nginx/sites-enabled/*;
+
+    server {
+        listen       80 default_server;
+        listen       [::]:80 default_server;
+        server_name  _;
+        root         /usr/share/nginx/html;
+
+        include /etc/nginx/default.d/*.conf;
+
+        location / {
+        }
+
+        error_page 404 /404.html;
+            location = /40x.html {
+        }
+
+        error_page 500 502 503 504 /50x.html;
+            location = /50x.html {
+        }
+    }
+}

--- a/packer/scripts/configureNginx.sh
+++ b/packer/scripts/configureNginx.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Script to install and setup Nginx and enable on boot.
+
+# Update system
+apt-get update -y
+apt-get upgrade -y
+
+# Install Nginx:
+apt-get install -y nginx
+
+# Start Nginx service and enable to start on boot
+systemctl enable nginx
+systemctl start nginx
+
+# Create a backup of the original configuration files and import configuration
+cp /etc/nginx/nginx.conf /etc/nginx/nginx.conf.original
+cp /tmp/nginx.conf /etc/nginx/nginx.conf
+
+# Setup a website with the desired server block and permissions
+mkdir -p /var/www/html/example.com
+chown -R www-data:www-data /var/www/html/example.com
+chmod 755 /var/www
+cp /tmp/example.com/example.com /etc/nginx/sites-available/example.com
+
+# Activate the host by creating a symbolic link between the sites-available directory and the sites-enabled directory
+ln -s /etc/nginx/sites-available/example.com /etc/nginx/sites-enabled/example.com
+
+# Delete the default nginx server block
+rm /etc/nginx/sites-enabled/default
+
+# Copy over the html test page:
+cp /tmp/example.com/index.html /var/www/html/example.com/index.html
+
+# Restart Nginx:
+systemctl restart nginx

--- a/packer/template.json
+++ b/packer/template.json
@@ -1,0 +1,33 @@
+{
+  "variables":
+  {
+    "digitalOceanApiToken": ""
+  },
+  "builders":
+  [
+    {
+      "type": "digitalocean",
+      "droplet_name": "Ubuntu1604x64-Packer",
+      "snapshot_name": "Ubuntu1604x64-Packer-{{timestamp}}",
+      "api_token": "{{ user `digitalOceanApiToken` }}",
+      "image": "ubuntu-16-04-x64",
+      "region": "nyc3",
+      "size": "512mb",
+      "ssh_username": "root"
+    }
+  ],
+  "provisioners":
+  [
+    {
+      "type": "file",
+      "source": "config/",
+      "destination": "/tmp"
+    },
+    {
+      "type": "shell",
+      "scripts": [
+        "scripts/configureNginx.sh"
+      ]
+    }
+  ]
+}

--- a/packer/variables.json
+++ b/packer/variables.json
@@ -1,0 +1,3 @@
+{
+  "digitalOceanApiToken": ""
+}


### PR DESCRIPTION
Created using tutorials with some modifications:

https://www.digitalocean.com/community/tutorials/how-to-create-digitalocean-snapshots-using-packer-on-ubuntu-16-04
https://www.digitalocean.com/community/tutorials/how-to-install-nginx-on-ubuntu-16-04

I ran `brew install packer` to install Packer on my machine.

From the 'packer' directory, validate the template by doing...

`packer validate -var-file=variables.json template.json`

From the 'packer' directory, build the tempalte by doing...

`packer build -var-file=variables.json template.json`

The main functional change I made to the tutorial was to use the `sites-enabled` folder instead of placing server blocks in `/etc/nginx/vhost.d/*.conf`

After turning the image into a droplet, run the following command and then restart Nginx:

`sudo sed -i 's/^.*server_name example.com/server_name [IP OF DROPLET]/' /etc/nginx/sites-available/example.com`